### PR TITLE
Add support for French

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -130,6 +130,12 @@ function infoservices_speakingclock($c) {
 		$ext->add($sub, $ex, '', new ext_sayunixtime('${FutureTime},,kM \\\'and\\\' S \\\'seconds\\\''));
 		$ext->add($sub, $ex, '', new ext_return(''));
 
+		// French specific language format
+		$ex = 'fr';
+		$ext->add($sub, $ex, '', new ext_playback('at-tone-time-exactly'));
+		$ext->add($sub, $ex, '', new ext_sayunixtime('${FutureTime},,kMS'));
+		$ext->add($sub, $ex, '', new ext_return(''));
+		
 		// German specific language format
 		$ex = 'de';
 		$ext->add($sub, $ex, '', new ext_playback('at-tone-time-exactly'));
@@ -157,6 +163,12 @@ function infoservices_speakingclock($c) {
 		$ext->add($sub, $ex, '', new ext_sayunixtime('${FutureTime},,IM \\\'and\\\' S \\\'seconds\\\' p'));
 		$ext->add($sub, $ex, '', new ext_return(''));
 
+		// French specific language format
+		$ex = 'fr';
+		$ext->add($sub, $ex, '', new ext_playback('at-tone-time-exactly'));
+		$ext->add($sub, $ex, '', new ext_sayunixtime('${FutureTime},,IMSp'));
+		$ext->add($sub, $ex, '', new ext_return(''));
+		
 		// German specific language format
 		$ex = 'de';
 		$ext->add($sub, $ex, '', new ext_playback('at-tone-time-exactly'));
@@ -205,6 +217,12 @@ function infoservices_speakingclock($c) {
 	$ext->add($id, $ex, '', new ext_sayunixtime('${FutureTime},,kM \\\'and\\\' S \\\'seconds\\\''));
 	$ext->add($id, $ex, '', new ext_return(''));
 
+	// French specific language format
+	$ex = 'fr';
+	$ext->add($id, $ex, '', new ext_playback('at-tone-time-exactly'));
+	$ext->add($id, $ex, '', new ext_sayunixtime('${FutureTime},,kMS'));
+	$ext->add($id, $ex, '', new ext_return(''));
+	
 	// German specific language format
 	$ex = 'de';
 	$ext->add($id, $ex, '', new ext_playback('at-tone-time-exactly'));
@@ -227,6 +245,12 @@ function infoservices_speakingclock($c) {
 	$ext->add($id, $ex, '', new ext_sayunixtime('${FutureTime},,IM \\\'and\\\' S \\\'seconds\\\' p'));
 	$ext->add($id, $ex, '', new ext_return(''));
 
+	// French specific language format
+	$ex = 'fr';
+	$ext->add($id, $ex, '', new ext_playback('at-tone-time-exactly'));
+	$ext->add($id, $ex, '', new ext_sayunixtime('${FutureTime},,IMSp'));
+	$ext->add($id, $ex, '', new ext_return(''));
+	
 	// German specific language format
 	$ex = 'de';
 	$ext->add($id, $ex, '', new ext_playback('at-tone-time-exactly'));
@@ -254,6 +278,7 @@ function infoservices_speakextennum($c) {
 	// Check for languages
 	$ext->add($id, $c, '', new ext_gotoif('$[${DIALPLAN_EXISTS('.$id.',${CHANNEL(language)},1)}]', $id.',${CHANNEL(language)},1',$id.',en,1'));
 
+	// English
 	$c = "en";
 	$ext->add($id, $c, '', new ext_playback('your'));
 	$ext->add($id, $c, '', new ext_playback('extension'));
@@ -262,6 +287,17 @@ function infoservices_speakextennum($c) {
 	$ext->add($id, $c, '', new ext_saydigits('${AMPUSER}'));
 	$ext->add($id, $c, '', new ext_wait('2')); // $cmd,n,Wait(1)
 	$ext->add($id, $c, '', new ext_hangup(''));
+	
+	// French
+	$c = "fr";
+	$ext->add($id, $c, '', new ext_playback('your'));
+	$ext->add($id, $c, '', new ext_playback('extension'));
+	$ext->add($id, $c, '', new ext_playback('is2'));
+	$ext->add($id, $c, '', new ext_saydigits('${AMPUSER}'));
+	$ext->add($id, $c, '', new ext_wait('2')); // $cmd,n,Wait(1)
+	$ext->add($id, $c, '', new ext_hangup(''));
+	
+	// Japanese
 	$c = "ja";
 	$ext->add($id, $c, '', new ext_playback('your'));
 	$ext->add($id, $c, '', new ext_playback('extension'));


### PR DESCRIPTION
Hi!

This add supports for French in the Info Services.

This is only a partial fix as there is currently a problem in Asterisk itself (and/or the way the sound files are distributed) which precludes this from working as intended.

Asterisk looks for a file called "second" in the "digits" directory and (ie "digits/second") when the sound file it should look for is the "seconds" one in the root language folder.

Since that file is missing the speaking clock aborts...

I am not quite sure what to do about the Asterisk part of the problem and if it's solely an Asterisk issue or a FreePBX as well (where are the sound files we install obtained from?).

Thank you and have a nice day!

Nicolas
